### PR TITLE
Bot 70

### DIFF
--- a/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
@@ -146,18 +146,22 @@
       debug:
         var: node_network_state.resources[0].status.currentState.interfaces
 
-    - name: Populate the node to port-id map
-      set_fact:
-        node_to_portid_map: "{{ node_to_portid_map | combine({ item.name: port_id }) }}"
-      loop: "{{ node_network_state.resources[0].status.currentState.interfaces }}"
-      loop_control:
-        loop_var: item
-      vars:
-        port_id: >-
-          {{
-            (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
-            if item.lldp is defined and item.lldp.enabled and item.lldp.neighbors | length > 0 else ''
-          }}
+- name: Populate the node to port-id map
+  set_fact:
+    node_to_portid_map: "{{ node_to_portid_map | combine({ item.name: port_id }) }}"
+  loop: "{{ node_network_state.resources[0].status.currentState.interfaces }}"
+  loop_control:
+    loop_var: item
+  vars:
+    port_id: >-
+      {{
+        item['lldp']['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default('')
+        if (item.get('lldp') is defined and
+            item['lldp'].get('enabled', False) and
+            'neighbors' in item['lldp'] and
+            item['lldp'].get('neighbors', []) | length > 0)
+        else ''
+      }}
 
     - name: Display the node to port-id map
       debug:

--- a/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
@@ -146,22 +146,22 @@
       debug:
         var: node_network_state.resources[0].status.currentState.interfaces
 
-- name: Populate the node to port-id map
-  set_fact:
-    node_to_portid_map: "{{ node_to_portid_map | combine({ item.name: port_id }) }}"
-  loop: "{{ node_network_state.resources[0].status.currentState.interfaces }}"
-  loop_control:
-    loop_var: item
-  vars:
-    port_id: >-
-      {{
-        item['lldp']['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default('')
-        if (item.get('lldp') is defined and
-            item['lldp'].get('enabled', False) and
-            'neighbors' in item['lldp'] and
-            item['lldp'].get('neighbors', []) | length > 0)
-        else ''
-      }}
+    - name: Populate the node to port-id map
+      set_fact:
+        node_to_portid_map: "{{ node_to_portid_map | combine({ item.name: port_id }) }}"
+      loop: "{{ node_network_state.resources[0].status.currentState.interfaces }}"
+      loop_control:
+        loop_var: item
+      vars:
+        port_id: >-
+          {{
+            (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
+            if (item.lldp is defined and
+                item.lldp.get('enabled', False) and
+                'neighbors' in item.lldp and
+                item.lldp.neighbors | length > 0)
+            else ''
+          }}
 
     - name: Display the node to port-id map
       debug:

--- a/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_create_connectivity_template/tasks/main.yml
@@ -177,7 +177,7 @@
 
     - name: Get the remote host from the node
       set_fact:
-        remote_host: "{{ remote_interface_json[0].lldp.neighbors[0][0]['system-name'] }}"
+        remote_host: "{{ remote_interface_json[0].lldp.neighbors[0][0]['system-name'] | split('.') | first }}"
 
     - name: Debug remote host
       debug:

--- a/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
@@ -182,6 +182,13 @@
   debug:
     var: node_network_state.resources[0].status.currentState.interfaces
 
+- name: Debug interfaces data
+  debug:
+    msg: "item: {{ item }}, lldp: {{ item.get('lldp', 'not defined') }}, neighbors: {{ item.get('lldp', {}).get('neighbors', 'not defined') }}"
+  loop: "{{ node_network_state.resources[0].status.currentState.interfaces }}"
+  loop_control:
+    loop_var: item
+
 - name: Populate the node to port-id map
   set_fact:
     node_to_portid_map: "{{ node_to_portid_map | combine({ item.name: port_id }) }}"
@@ -191,11 +198,11 @@
   vars:
     port_id: >-
       {{
-        (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
-        if (item.lldp is defined and
-            item.lldp.get('enabled', False) and
-            'neighbors' in item.lldp and
-            item.lldp.neighbors | length > 0)
+        item['lldp']['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default('')
+        if (item.get('lldp') is defined and
+            item['lldp'].get('enabled', False) and
+            'neighbors' in item['lldp'] and
+            item['lldp'].get('neighbors', []) | length > 0)
         else ''
       }}
 

--- a/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
@@ -191,8 +191,11 @@
   vars:
     port_id: >-
       {{
-        (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
-        if item.lldp is defined and item.lldp.enabled and item.lldp.neighbors | length > 0 else ''
+        (item.lldp['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
+        if (item.get('lldp') is defined and
+            item.lldp.get('enabled', False) and
+            item.lldp.get('neighbors', []) | length > 0)
+        else ''
       }}
 
 - name: Display the node to port-id map

--- a/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
@@ -198,11 +198,11 @@
   vars:
     port_id: >-
       {{
-        item['lldp']['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default('')
-        if (item.get('lldp') is defined and
-            item['lldp'].get('enabled', False) and
-            'neighbors' in item['lldp'] and
-            item['lldp'].get('neighbors', []) | length > 0)
+        (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
+        if (item.lldp is defined and
+            item.lldp.get('enabled', False) and
+            'neighbors' in item.lldp and
+            item.lldp.neighbors | length > 0)
         else ''
       }}
 
@@ -220,7 +220,7 @@
 
 - name: Get the remote host from the node
   set_fact:
-    remote_host: "{{ remote_interface_json[0].lldp.neighbors[0][0]['system-name'] }}"   
+    remote_host: "{{ remote_interface_json[0].lldp.neighbors[0][0]['system-name'] | split('.') | first }}"   
 
 - name: Initialize application points
   set_fact:

--- a/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
+++ b/playbooks/roles/k8s_delete_connectivity_template/tasks/main.yml
@@ -191,10 +191,11 @@
   vars:
     port_id: >-
       {{
-        (item.lldp['neighbors'][0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
-        if (item.get('lldp') is defined and
+        (item.lldp.neighbors[0] | selectattr('port-id', 'defined') | map(attribute='port-id') | first | default(''))
+        if (item.lldp is defined and
             item.lldp.get('enabled', False) and
-            item.lldp.get('neighbors', []) | length > 0)
+            'neighbors' in item.lldp and
+            item.lldp.neighbors | length > 0)
         else ''
       }}
 


### PR DESCRIPTION
Undefined variable error for lldp neighbors

encountering error in  Ansible task indicates that item.lldp.neighbors is being accessed on an object where lldp is a dictionary, but it either doesn't have a neighbors key or lldp itself is not defined properly in some cases. This is causing Ansible to fail when it tries to evaluate the Jinja2 expression in the port_id variable