### PR TITLE
Add VNI pool assignment to security zone tasks

### DIFF
--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -137,20 +137,9 @@
       register: rg_response
       when: vni_pool_name | length > 0 or loopback_pool_name | length > 0
 
-    - name: Set VNI resource groups dynamically from API response
-      ansible.builtin.set_fact:
-        vni_resource_groups: >-
-          {{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}
-      when: vni_pool_name | length > 0
-
-    - name: Debug - print vni_pool_id and all VNI resource groups
-      debug:
-        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' groups={{ vni_resource_groups | map(attribute='name') | list }}"
-      when: vni_pool_name | length > 0
-
-    - name: Assign VNI pool to all VNI resource groups
+    - name: Assign VNI pool to evpn_l3_vnis resource group
       ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ item.name }}"
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/evpn_l3_vnis"
         method: PUT
         headers:
           AuthToken: "{{ auth.token }}"
@@ -161,15 +150,12 @@
             - "{{ vni_pool_id }}"
         validate_certs: false
         status_code: [200, 202, 204]
-      loop: "{{ vni_resource_groups }}"
-      loop_control:
-        label: "{{ item.name }}"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
       register: vni_assignment
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to all VNI resource groups: {{ vni_resource_groups | map(attribute='name') | list }}"
+        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to evpn_l3_vnis"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
 
     # ── Loopback IP pool assignment ───────────────────────────────────────

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -117,17 +117,28 @@
           }}
       when: vni_pool_name | length > 0
 
-    - name: Debug - show all resource groups for blueprint
+    - name: Get all resource groups from blueprint via raw API
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups"
+        method: GET
+        headers:
+          AuthToken: "{{ auth.token }}"
+        validate_certs: false
+        status_code: 200
+      register: rg_response
+      when: vni_pool_name | length > 0
+
+    - name: Debug - show all VNI resource groups from API
       debug:
-        msg: "{{ ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups | selectattr('resource_type', 'equalto', 'vni') | list }}"
+        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}"
       when: vni_pool_name | length > 0
 
     - name: Find VNI resource group name for this security zone
       ansible.builtin.set_fact:
         sz_vni_rg_name: >-
           {{
-            ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups
-            | selectattr('resource_type', 'equalto', 'vni')
+            rg_response.json['items']
+            | selectattr('type', 'equalto', 'vni')
             | selectattr('name', 'search', sz.id.security_zone)
             | map(attribute='name')
             | first

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -137,26 +137,14 @@
       register: rg_response
       when: vni_pool_name | length > 0 or loopback_pool_name | length > 0
 
-    - name: Find all VNI resource groups
+    - name: Set VNI resource groups dynamically from API response
       ansible.builtin.set_fact:
-        vni_resource_groups: >-
-          {{ rg_response.json['items']
-             | selectattr('type', 'equalto', 'vni')
-             | list }}
+        vni_resource_groups: "{{ rg_response.json['items'] | json_query('[?type==`vni`]') }}"
       when: vni_pool_name | length > 0
 
     - name: Debug - print vni_pool_id and all VNI resource groups
       debug:
         msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' groups={{ vni_resource_groups | map(attribute='name') | list }}"
-      when: vni_pool_name | length > 0
-
-    - name: Debug - print full VNI resource groups list
-      debug:
-        msg: "VNI resource group {{ idx + 1 }}: name='{{ item.name }}' type='{{ item.type }}' pool_ids={{ item.pool_ids }}"
-      loop: "{{ vni_resource_groups }}"
-      loop_control:
-        index_var: idx
-        label: "{{ item.name }}"
       when: vni_pool_name | length > 0
 
     - name: Assign VNI pool to all VNI resource groups
@@ -199,13 +187,7 @@
 
     - name: Find all loopback IP resource groups (leaf_loopback_ips)
       ansible.builtin.set_fact:
-        loopback_resource_groups: >-
-          {{
-            rg_response.json['items']
-            | selectattr('type', 'equalto', 'ip')
-            | selectattr('name', 'search', 'leaf_loopback_ips')
-            | list
-          }}
+        loopback_resource_groups: "{{ rg_response.json['items'] | json_query('[?type==`ip` && contains(name, `leaf_loopback_ips`)]') }}"
       when: loopback_pool_name | length > 0
 
     - name: Debug - print loopback_pool_id and all matching resource groups

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -139,7 +139,8 @@
 
     - name: Set VNI resource groups dynamically from API response
       ansible.builtin.set_fact:
-        vni_resource_groups: "{{ rg_response.json['items'] | json_query('[?type==`vni`]') }}"
+        vni_resource_groups: >-
+          {{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}
       when: vni_pool_name | length > 0
 
     - name: Debug - print vni_pool_id and all VNI resource groups
@@ -187,7 +188,8 @@
 
     - name: Find all loopback IP resource groups (leaf_loopback_ips)
       ansible.builtin.set_fact:
-        loopback_resource_groups: "{{ rg_response.json['items'] | json_query('[?type==`ip` && contains(name, `leaf_loopback_ips`)]') }}"
+        loopback_resource_groups: >-
+          {{ rg_response.json['items'] | selectattr('type', 'equalto', 'ip') | selectattr('name', 'search', 'leaf_loopback_ips') | list }}
       when: loopback_pool_name | length > 0
 
     - name: Debug - print loopback_pool_id and all matching resource groups

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -128,32 +128,22 @@
       register: rg_response
       when: vni_pool_name | length > 0
 
-    - name: Debug - show all VNI resource groups from API
-      debug:
-        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}"
-      when: vni_pool_name | length > 0
-
-    - name: Find VNI resource group name for this security zone
+    - name: Find VNI resource group
       ansible.builtin.set_fact:
-        sz_vni_rg_name: >-
-          {{
-            rg_response.json['items']
-            | selectattr('type', 'equalto', 'vni')
-            | selectattr('name', 'search', sz.id.security_zone)
-            | map(attribute='name')
-            | first
-            | default('')
-          }}
+        vni_resource_group: >-
+          {{ rg_response.json.items
+             | selectattr('resource_type', 'equalto', 'vni')
+             | first }}
       when: vni_pool_name | length > 0
 
-    - name: Debug - print vni_pool_id and resource group name
+    - name: Debug - print vni_pool_id and resource group
       debug:
-        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id }}' sz_vni_rg_name='{{ sz_vni_rg_name }}'"
+        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' group_name='{{ vni_resource_group.group_name | default('') }}'"
       when: vni_pool_name | length > 0
 
-    - name: Assign VNI pool to security zone routing zone
+    - name: Assign VNI pool to blueprint routing zone
       ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ sz_vni_rg_name }}"
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ vni_resource_group.group_name }}"
         method: PUT
         headers:
           AuthToken: "{{ auth.token }}"
@@ -164,13 +154,13 @@
             - "{{ vni_pool_id }}"
         validate_certs: false
         status_code: [200, 202, 204]
-      when: vni_pool_name | length > 0 and vni_pool_id | length > 0 and sz_vni_rg_name | length > 0
+      when: vni_pool_name | length > 0 and vni_pool_id | length > 0
       register: vni_assignment
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ sz_vni_rg_name }}'"
-      when: vni_pool_name | length > 0 and vni_pool_id | length > 0 and sz_vni_rg_name | length > 0
+        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ vni_resource_group.group_name }}'"
+      when: vni_pool_name | length > 0 and vni_pool_id | length > 0
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -150,6 +150,15 @@
         msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' groups={{ vni_resource_groups | map(attribute='name') | list }}"
       when: vni_pool_name | length > 0
 
+    - name: Debug - print full VNI resource groups list
+      debug:
+        msg: "VNI resource group {{ idx + 1 }}: name='{{ item.name }}' type='{{ item.type }}' pool_ids={{ item.pool_ids }}"
+      loop: "{{ vni_resource_groups }}"
+      loop_control:
+        index_var: idx
+        label: "{{ item.name }}"
+      when: vni_pool_name | length > 0
+
     - name: Assign VNI pool to all VNI resource groups
       ansible.builtin.uri:
         url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ item.name }}"

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -90,25 +90,64 @@
         tags: "{{ sz_tags if sz_tags is not none else omit }}"
       register: sz
 
+    - name: Debug - print vni_pool_name and security zone ID
+      debug:
+        msg: "vni_pool_name='{{ vni_pool_name }}' sz_id='{{ sz.id.security_zone }}'"
+      when: vni_pool_name | length > 0
+
+    - name: Get all resource groups from blueprint
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups"
+        method: GET
+        headers:
+          AuthToken: "{{ auth.token }}"
+        validate_certs: false
+        status_code: 200
+      register: rg_response
+      when: vni_pool_name | length > 0
+
+    - name: Debug - show all VNI resource groups
+      debug:
+        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}"
+      when: vni_pool_name | length > 0
+
+    - name: Find VNI resource group name for this security zone
+      ansible.builtin.set_fact:
+        sz_vni_rg_name: >-
+          {{
+            rg_response.json['items']
+            | selectattr('type', 'equalto', 'vni')
+            | selectattr('name', 'search', sz.id.security_zone)
+            | map(attribute='name')
+            | first
+            | default('')
+          }}
+      when: vni_pool_name | length > 0
+
+    - name: Debug - print discovered VNI resource group name
+      debug:
+        msg: "Discovered VNI resource group: '{{ sz_vni_rg_name }}'"
+      when: vni_pool_name | length > 0
+
     - name: Assign VNI pool to security zone routing zone
       juniper.apstra.resource_group:
         id:
           blueprint: "{{ register_bp.id.blueprint }}"
           group_type: "vni"
-          group_name: "sz:{{ sz.id.security_zone }},vni_virtual_network_id"
+          group_name: "{{ sz_vni_rg_name }}"
         body:
           pool_ids:
             - "{{ vni_pool_name }}"
         auth_token: "{{ auth.token }}"
         verify_certificates: false
         state: present
-      when: vni_pool_name | length > 0
+      when: vni_pool_name | length > 0 and sz_vni_rg_name | length > 0
       register: vni_assignment
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' assigned to security zone {{ sz.id.security_zone }}"
-      when: vni_pool_name | length > 0 and vni_assignment.changed
+        msg: "VNI pool '{{ vni_pool_name }}' assigned to resource group '{{ sz_vni_rg_name }}'"
+      when: vni_pool_name | length > 0 and sz_vni_rg_name | length > 0
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -37,6 +37,10 @@
   ansible.builtin.set_fact:
     vni_pool_name: "{{ vrf_data.vniPoolName | default('') }}"
 
+- name: Set loopback pool name from annotation if defined
+  ansible.builtin.set_fact:
+    loopback_pool_name: "{{ vrf_data.loopbackPoolName | default('') }}"
+
 - name: Print vrf_data_with_sztype
   debug:
     msg: "{{ vrf_data_with_sztype }}"
@@ -90,14 +94,15 @@
         tags: "{{ sz_tags if sz_tags is not none else omit }}"
       register: sz
 
-    - name: Gather VNI pools and blueprint resource groups from Apstra
+    - name: Gather VNI pools, IP pools and blueprint resource groups from Apstra
       juniper.apstra.apstra_facts:
         id: "{{ register_bp.id }}"
         auth_token: "{{ auth.token }}"
         gather_network_facts:
           - blueprints.resource_groups
           - vni_pools
-      when: vni_pool_name | length > 0
+          - ip_pools
+      when: vni_pool_name | length > 0 or loopback_pool_name | length > 0
 
     - name: Debug - show all VNI pools
       debug:
@@ -126,7 +131,7 @@
         validate_certs: false
         status_code: 200
       register: rg_response
-      when: vni_pool_name | length > 0
+      when: vni_pool_name | length > 0 or loopback_pool_name | length > 0
 
     - name: Find VNI resource group
       ansible.builtin.set_fact:
@@ -161,6 +166,58 @@
       debug:
         msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ vni_resource_group.name }}'"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
+
+    # ── Loopback IP pool assignment ───────────────────────────────────────
+    - name: Find loopback IP pool ID by display_name
+      ansible.builtin.set_fact:
+        loopback_pool_id: >-
+          {{
+            ansible_facts.apstra_facts.ip_pools
+            | dict2items
+            | selectattr('value.display_name', 'equalto', loopback_pool_name)
+            | map(attribute='key')
+            | first
+            | default('')
+          }}
+      when: loopback_pool_name | length > 0
+
+    - name: Find loopback resource group for this security zone
+      ansible.builtin.set_fact:
+        loopback_resource_group: >-
+          {{
+            rg_response.json['items']
+            | selectattr('type', 'equalto', 'ip')
+            | selectattr('name', 'search', 'sz:' ~ sz.id.security_zone ~ ',leaf_loopback_ips')
+            | first
+            | default({})
+          }}
+      when: loopback_pool_name | length > 0
+
+    - name: Debug - print loopback_pool_id and resource group name
+      debug:
+        msg: "loopback_pool_name='{{ loopback_pool_name }}' loopback_pool_id='{{ loopback_pool_id | default('') }}' rg_name='{{ loopback_resource_group.name | default('') }}'"
+      when: loopback_pool_name | length > 0
+
+    - name: Assign loopback IP pool to security zone leaf_loopback_ips resource group
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/ip/{{ loopback_resource_group.name }}"
+        method: PUT
+        headers:
+          AuthToken: "{{ auth.token }}"
+          Content-Type: "application/json"
+        body_format: json
+        body:
+          pool_ids:
+            - "{{ loopback_pool_id }}"
+        validate_certs: false
+        status_code: [200, 202, 204]
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0 and loopback_resource_group.name is defined
+      register: loopback_assignment
+
+    - name: Print loopback pool assignment result
+      debug:
+        msg: "Loopback pool '{{ loopback_pool_name }}' (id={{ loopback_pool_id }}) assigned to resource group '{{ loopback_resource_group.name }}'"
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0 and loopback_resource_group.name is defined
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -207,6 +207,27 @@
         msg: "Loopback pool '{{ loopback_pool_name }}' (id={{ loopback_pool_id }}) assigned to all leaf_loopback_ips resource groups: {{ loopback_resource_groups | map(attribute='name') | list }}"
       when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0
 
+    - name: Assign loopback IP pool to sz-specific leaf_loopback_ips resource group
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/ip/sz:{{ sz.id.security_zone }},leaf_loopback_ips"
+        method: PUT
+        headers:
+          AuthToken: "{{ auth.token }}"
+          Content-Type: "application/json"
+        body_format: json
+        body:
+          pool_ids:
+            - "{{ loopback_pool_id }}"
+        validate_certs: false
+        status_code: [200, 202, 204]
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0
+      register: sz_loopback_assignment
+
+    - name: Print sz-specific loopback pool assignment result
+      debug:
+        msg: "Loopback pool '{{ loopback_pool_name }}' assigned to sz:{{ sz.id.security_zone }},leaf_loopback_ips"
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0
+
     - name: If changes are made, print changed
       debug:
         msg: "{{ sz.changed }}"

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -206,7 +206,7 @@
           {{
             rg_response.json['items']
             | selectattr('type', 'equalto', 'ip')
-            | selectattr('name', 'search', 'sz:' ~ sz.id.security_zone ~ ',leaf_loopback_ips')
+            | selectattr('name', 'equalto', 'leaf_loopback_ips')
             | first
             | default({})
           }}

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -90,64 +90,77 @@
         tags: "{{ sz_tags if sz_tags is not none else omit }}"
       register: sz
 
-    - name: Debug - print vni_pool_name and security zone ID
-      debug:
-        msg: "vni_pool_name='{{ vni_pool_name }}' sz_id='{{ sz.id.security_zone }}'"
+    - name: Gather VNI pools and blueprint resource groups from Apstra
+      juniper.apstra.apstra_facts:
+        id: "{{ register_bp.id }}"
+        auth_token: "{{ auth.token }}"
+        gather_network_facts:
+          - blueprints.resource_groups
+          - vni_pools
       when: vni_pool_name | length > 0
 
-    - name: Get all resource groups from blueprint
-      ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups"
-        method: GET
-        headers:
-          AuthToken: "{{ auth.token }}"
-        validate_certs: false
-        status_code: 200
-      register: rg_response
+    - name: Debug - show all VNI pools
+      debug:
+        msg: "{{ ansible_facts.apstra_facts.vni_pools | dict2items | map(attribute='value') | map(attribute='display_name') | list }}"
       when: vni_pool_name | length > 0
 
-    - name: Debug - show all VNI resource groups
+    - name: Find VNI pool ID by display_name
+      ansible.builtin.set_fact:
+        vni_pool_id: >-
+          {{
+            ansible_facts.apstra_facts.vni_pools
+            | dict2items
+            | selectattr('value.display_name', 'equalto', vni_pool_name)
+            | map(attribute='key')
+            | first
+            | default('')
+          }}
+      when: vni_pool_name | length > 0
+
+    - name: Debug - show all resource groups for blueprint
       debug:
-        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'vni') | list }}"
+        msg: "{{ ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups | dict2items | selectattr('value.resource_type', 'equalto', 'vni') | list }}"
       when: vni_pool_name | length > 0
 
     - name: Find VNI resource group name for this security zone
       ansible.builtin.set_fact:
         sz_vni_rg_name: >-
           {{
-            rg_response.json['items']
-            | selectattr('type', 'equalto', 'vni')
-            | selectattr('name', 'search', sz.id.security_zone)
-            | map(attribute='name')
+            ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups
+            | dict2items
+            | selectattr('value.resource_type', 'equalto', 'vni')
+            | selectattr('key', 'search', sz.id.security_zone)
+            | map(attribute='key')
             | first
             | default('')
           }}
       when: vni_pool_name | length > 0
 
-    - name: Debug - print discovered VNI resource group name
+    - name: Debug - print vni_pool_id and resource group name
       debug:
-        msg: "Discovered VNI resource group: '{{ sz_vni_rg_name }}'"
+        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id }}' sz_vni_rg_name='{{ sz_vni_rg_name }}'"
       when: vni_pool_name | length > 0
 
     - name: Assign VNI pool to security zone routing zone
-      juniper.apstra.resource_group:
-        id:
-          blueprint: "{{ register_bp.id.blueprint }}"
-          group_type: "vni"
-          group_name: "{{ sz_vni_rg_name }}"
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ sz_vni_rg_name }}"
+        method: PUT
+        headers:
+          AuthToken: "{{ auth.token }}"
+          Content-Type: "application/json"
+        body_format: json
         body:
           pool_ids:
-            - "{{ vni_pool_name }}"
-        auth_token: "{{ auth.token }}"
-        verify_certificates: false
-        state: present
-      when: vni_pool_name | length > 0 and sz_vni_rg_name | length > 0
+            - "{{ vni_pool_id }}"
+        validate_certs: false
+        status_code: [200, 202, 204]
+      when: vni_pool_name | length > 0 and vni_pool_id | length > 0 and sz_vni_rg_name | length > 0
       register: vni_assignment
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' assigned to resource group '{{ sz_vni_rg_name }}'"
-      when: vni_pool_name | length > 0 and sz_vni_rg_name | length > 0
+        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ sz_vni_rg_name }}'"
+      when: vni_pool_name | length > 0 and vni_pool_id | length > 0 and sz_vni_rg_name | length > 0
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -182,6 +182,11 @@
         msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'ip') | map(attribute='name') | list }}"
       when: loopback_pool_name | length > 0
 
+    - name: Debug - show ALL resource group names and types (unfiltered)
+      debug:
+        msg: "{{ rg_response.json['items'] | map(attribute='name') | list }}"
+      when: loopback_pool_name | length > 0
+
     - name: Find loopback IP pool ID by display_name
       ansible.builtin.set_fact:
         loopback_pool_id: >-

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -131,19 +131,19 @@
     - name: Find VNI resource group
       ansible.builtin.set_fact:
         vni_resource_group: >-
-          {{ rg_response.json.items
-             | selectattr('resource_type', 'equalto', 'vni')
+          {{ rg_response.json['items']
+             | selectattr('type', 'equalto', 'vni')
              | first }}
       when: vni_pool_name | length > 0
 
     - name: Debug - print vni_pool_id and resource group
       debug:
-        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' group_name='{{ vni_resource_group.group_name | default('') }}'"
+        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' group_name='{{ vni_resource_group.name | default('') }}'"
       when: vni_pool_name | length > 0
 
     - name: Assign VNI pool to blueprint routing zone
       ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ vni_resource_group.group_name }}"
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ vni_resource_group.name }}"
         method: PUT
         headers:
           AuthToken: "{{ auth.token }}"
@@ -159,7 +159,7 @@
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ vni_resource_group.group_name }}'"
+        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ vni_resource_group.name }}'"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
 
     - name: If changes are made, print changed

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -119,7 +119,7 @@
 
     - name: Debug - show all resource groups for blueprint
       debug:
-        msg: "{{ ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups | dict2items | selectattr('value.resource_type', 'equalto', 'vni') | list }}"
+        msg: "{{ ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups | selectattr('resource_type', 'equalto', 'vni') | list }}"
       when: vni_pool_name | length > 0
 
     - name: Find VNI resource group name for this security zone
@@ -127,10 +127,9 @@
         sz_vni_rg_name: >-
           {{
             ansible_facts.apstra_facts.blueprints[register_bp.id.blueprint].resource_groups
-            | dict2items
-            | selectattr('value.resource_type', 'equalto', 'vni')
-            | selectattr('key', 'search', sz.id.security_zone)
-            | map(attribute='key')
+            | selectattr('resource_type', 'equalto', 'vni')
+            | selectattr('name', 'search', sz.id.security_zone)
+            | map(attribute='name')
             | first
             | default('')
           }}

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -41,6 +41,10 @@
   ansible.builtin.set_fact:
     loopback_pool_name: "{{ vrf_data.loopbackPoolName | default('') }}"
 
+- name: Debug - print pool names resolved from annotation
+  debug:
+    msg: "vni_pool_name='{{ vni_pool_name }}' loopback_pool_name='{{ loopback_pool_name }}' vrf_data={{ vrf_data }}"
+
 - name: Print vrf_data_with_sztype
   debug:
     msg: "{{ vrf_data_with_sztype }}"
@@ -168,6 +172,16 @@
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
 
     # ── Loopback IP pool assignment ───────────────────────────────────────
+    - name: Debug - show all IP pools
+      debug:
+        msg: "{{ ansible_facts.apstra_facts.ip_pools | dict2items | map(attribute='value') | map(attribute='display_name') | list }}"
+      when: loopback_pool_name | length > 0
+
+    - name: Debug - show all IP resource groups
+      debug:
+        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'ip') | map(attribute='name') | list }}"
+      when: loopback_pool_name | length > 0
+
     - name: Find loopback IP pool ID by display_name
       ansible.builtin.set_fact:
         loopback_pool_id: >-

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -33,6 +33,10 @@
         | combine({'vrf_name': (vrf_data.vrfName if vrf_data.vrfName is defined else vrf_data.label)})
       }}
 
+- name: Set VNI pool name from annotation if defined
+  ansible.builtin.set_fact:
+    vni_pool_name: "{{ vrf_data.vniPoolName | default('') }}"
+
 - name: Print vrf_data_with_sztype
   debug:
     msg: "{{ vrf_data_with_sztype }}"
@@ -85,6 +89,26 @@
         auth_token: "{{ auth.token }}"
         tags: "{{ sz_tags if sz_tags is not none else omit }}"
       register: sz
+
+    - name: Assign VNI pool to security zone routing zone
+      juniper.apstra.resource_group:
+        id:
+          blueprint: "{{ register_bp.id.blueprint }}"
+          group_type: "vni"
+          group_name: "sz:{{ sz.id.security_zone }},vni_virtual_network_id"
+        body:
+          pool_ids:
+            - "{{ vni_pool_name }}"
+        auth_token: "{{ auth.token }}"
+        verify_certificates: false
+        state: present
+      when: vni_pool_name | length > 0
+      register: vni_assignment
+
+    - name: Print VNI pool assignment result
+      debug:
+        msg: "VNI pool '{{ vni_pool_name }}' assigned to security zone {{ sz.id.security_zone }}"
+      when: vni_pool_name | length > 0 and vni_assignment.changed
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_security_zone/tasks/main.yml
+++ b/playbooks/roles/k8s_create_security_zone/tasks/main.yml
@@ -137,22 +137,22 @@
       register: rg_response
       when: vni_pool_name | length > 0 or loopback_pool_name | length > 0
 
-    - name: Find VNI resource group
+    - name: Find all VNI resource groups
       ansible.builtin.set_fact:
-        vni_resource_group: >-
+        vni_resource_groups: >-
           {{ rg_response.json['items']
              | selectattr('type', 'equalto', 'vni')
-             | first }}
+             | list }}
       when: vni_pool_name | length > 0
 
-    - name: Debug - print vni_pool_id and resource group
+    - name: Debug - print vni_pool_id and all VNI resource groups
       debug:
-        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' group_name='{{ vni_resource_group.name | default('') }}'"
+        msg: "vni_pool_name='{{ vni_pool_name }}' vni_pool_id='{{ vni_pool_id | default('') }}' groups={{ vni_resource_groups | map(attribute='name') | list }}"
       when: vni_pool_name | length > 0
 
-    - name: Assign VNI pool to blueprint routing zone
+    - name: Assign VNI pool to all VNI resource groups
       ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ vni_resource_group.name }}"
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/{{ item.name }}"
         method: PUT
         headers:
           AuthToken: "{{ auth.token }}"
@@ -163,30 +163,18 @@
             - "{{ vni_pool_id }}"
         validate_certs: false
         status_code: [200, 202, 204]
+      loop: "{{ vni_resource_groups }}"
+      loop_control:
+        label: "{{ item.name }}"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
       register: vni_assignment
 
     - name: Print VNI pool assignment result
       debug:
-        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to resource group '{{ vni_resource_group.name }}'"
+        msg: "VNI pool '{{ vni_pool_name }}' (id={{ vni_pool_id }}) assigned to all VNI resource groups: {{ vni_resource_groups | map(attribute='name') | list }}"
       when: vni_pool_name | length > 0 and vni_pool_id | length > 0
 
     # ── Loopback IP pool assignment ───────────────────────────────────────
-    - name: Debug - show all IP pools
-      debug:
-        msg: "{{ ansible_facts.apstra_facts.ip_pools | dict2items | map(attribute='value') | map(attribute='display_name') | list }}"
-      when: loopback_pool_name | length > 0
-
-    - name: Debug - show all IP resource groups
-      debug:
-        msg: "{{ rg_response.json['items'] | selectattr('type', 'equalto', 'ip') | map(attribute='name') | list }}"
-      when: loopback_pool_name | length > 0
-
-    - name: Debug - show ALL resource group names and types (unfiltered)
-      debug:
-        msg: "{{ rg_response.json['items'] | map(attribute='name') | list }}"
-      when: loopback_pool_name | length > 0
-
     - name: Find loopback IP pool ID by display_name
       ansible.builtin.set_fact:
         loopback_pool_id: >-
@@ -200,26 +188,25 @@
           }}
       when: loopback_pool_name | length > 0
 
-    - name: Find loopback resource group for this security zone
+    - name: Find all loopback IP resource groups (leaf_loopback_ips)
       ansible.builtin.set_fact:
-        loopback_resource_group: >-
+        loopback_resource_groups: >-
           {{
             rg_response.json['items']
             | selectattr('type', 'equalto', 'ip')
-            | selectattr('name', 'equalto', 'leaf_loopback_ips')
-            | first
-            | default({})
+            | selectattr('name', 'search', 'leaf_loopback_ips')
+            | list
           }}
       when: loopback_pool_name | length > 0
 
-    - name: Debug - print loopback_pool_id and resource group name
+    - name: Debug - print loopback_pool_id and all matching resource groups
       debug:
-        msg: "loopback_pool_name='{{ loopback_pool_name }}' loopback_pool_id='{{ loopback_pool_id | default('') }}' rg_name='{{ loopback_resource_group.name | default('') }}'"
+        msg: "loopback_pool_name='{{ loopback_pool_name }}' loopback_pool_id='{{ loopback_pool_id | default('') }}' groups={{ loopback_resource_groups | map(attribute='name') | list }}"
       when: loopback_pool_name | length > 0
 
-    - name: Assign loopback IP pool to security zone leaf_loopback_ips resource group
+    - name: Assign loopback IP pool to all leaf_loopback_ips resource groups
       ansible.builtin.uri:
-        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/ip/{{ loopback_resource_group.name }}"
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/ip/{{ item.name }}"
         method: PUT
         headers:
           AuthToken: "{{ auth.token }}"
@@ -230,13 +217,16 @@
             - "{{ loopback_pool_id }}"
         validate_certs: false
         status_code: [200, 202, 204]
-      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0 and loopback_resource_group.name is defined
+      loop: "{{ loopback_resource_groups }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0
       register: loopback_assignment
 
     - name: Print loopback pool assignment result
       debug:
-        msg: "Loopback pool '{{ loopback_pool_name }}' (id={{ loopback_pool_id }}) assigned to resource group '{{ loopback_resource_group.name }}'"
-      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0 and loopback_resource_group.name is defined
+        msg: "Loopback pool '{{ loopback_pool_name }}' (id={{ loopback_pool_id }}) assigned to all leaf_loopback_ips resource groups: {{ loopback_resource_groups | map(attribute='name') | list }}"
+      when: loopback_pool_name | length > 0 and loopback_pool_id | length > 0
 
     - name: If changes are made, print changed
       debug:

--- a/playbooks/roles/k8s_create_virtual_network/tasks/main.yml
+++ b/playbooks/roles/k8s_create_virtual_network/tasks/main.yml
@@ -79,6 +79,10 @@
   set_fact:
     sz_label_value: "{{ (annotations['apstra.juniper.net/vnet'] | regex_search('\"vrfName\": \"([^\"]+)\"', '\\1') | first) | string }}"
 
+- name: Extract VNI pool name from vnet annotation if defined
+  ansible.builtin.set_fact:
+    vnet_vni_pool_name: "{{ vnet_data.vniPoolName | default('') }}"
+
 
 - name: Connect to Apstra
   juniper.apstra.authenticate:
@@ -234,6 +238,49 @@
       retries: 5
       delay: 10
       until: vn.failed == false
+
+    # ── Assign VNI pool to vxlan_vn_ids (available after VN creation) ──────
+    - name: Gather VNI pools for vxlan_vn_ids assignment
+      juniper.apstra.apstra_facts:
+        id: "{{ register_bp.id }}"
+        auth_token: "{{ auth.token }}"
+        gather_network_facts:
+          - vni_pools
+      when: vnet_vni_pool_name | length > 0
+
+    - name: Find VNI pool ID by display_name for vxlan_vn_ids
+      ansible.builtin.set_fact:
+        vnet_vni_pool_id: >-
+          {{
+            ansible_facts.apstra_facts.vni_pools
+            | dict2items
+            | selectattr('value.display_name', 'equalto', vnet_vni_pool_name)
+            | map(attribute='key')
+            | first
+            | default('')
+          }}
+      when: vnet_vni_pool_name | length > 0
+
+    - name: Assign VNI pool to vxlan_vn_ids resource group
+      ansible.builtin.uri:
+        url: "{{ lookup('env', 'APSTRA_API_URL') }}/blueprints/{{ register_bp.id.blueprint }}/resource_groups/vni/vxlan_vn_ids"
+        method: PUT
+        headers:
+          AuthToken: "{{ auth.token }}"
+          Content-Type: "application/json"
+        body_format: json
+        body:
+          pool_ids:
+            - "{{ vnet_vni_pool_id }}"
+        validate_certs: false
+        status_code: [200, 202, 204]
+      when: vnet_vni_pool_name | length > 0 and vnet_vni_pool_id | length > 0
+      register: vxlan_vni_assignment
+
+    - name: Print vxlan_vn_ids assignment result
+      debug:
+        msg: "VNI pool '{{ vnet_vni_pool_name }}' (id={{ vnet_vni_pool_id }}) assigned to vxlan_vn_ids"
+      when: vnet_vni_pool_name | length > 0 and vnet_vni_pool_id | length > 0
   
     - name: Get the resource_groups
       juniper.apstra.apstra_facts:

--- a/playbooks/roles/k8s_create_virtual_network/tasks/main.yml
+++ b/playbooks/roles/k8s_create_virtual_network/tasks/main.yml
@@ -281,33 +281,6 @@
       debug:
         msg: "VNI pool '{{ vnet_vni_pool_name }}' (id={{ vnet_vni_pool_id }}) assigned to vxlan_vn_ids"
       when: vnet_vni_pool_name | length > 0 and vnet_vni_pool_id | length > 0
-  
-    - name: Get the resource_groups
-      juniper.apstra.apstra_facts:
-        id: "{{ register_bp.id }}"
-        auth_token: "{{ auth.token }}"
-        gather_network_facts:
-          - blueprints.resource_groups
-          - ip_pools
-
-    - name: Extract list of ip_pool ids
-      ansible.builtin.set_fact:
-        ip_pools: "{{ ansible_facts.apstra_facts.ip_pools | json_query('keys(@)') }}"
-
-    - name: Show ip_pool_ids
-      ansible.builtin.debug:
-        var: ip_pools
-
-    - name: Update resource_group
-      juniper.apstra.resource_group:
-        id:
-          blueprint: "{{ register_bp.id.blueprint }}"
-          group_type: "ip"
-          group_name: "sz:{{ sz.security_zone.id }},leaf_loopback_ips"
-        body:
-          description: "Updated description"
-          pool_ids: "{{ ip_pools }}"
-      register: rg_update
 
     - name: Create NS for the configmap
       kubernetes.core.k8s:


### PR DESCRIPTION
## Summary

### Problem
When creating a routing zone (security zone) in Apstra via EDA, the blueprint commit was failing with:

> `vni_id is not configured for routing zone "vrf-demo"`

Apstra requires VNI pools assigned to `evpn_l3_vnis` and `vxlan_vn_ids` resource groups, and an IP pool assigned to `leaf_loopback_ips`, before a blueprint with EVPN routing zones can be committed successfully.

---

### Root Cause
The EDA playbooks were creating the routing zone and virtual networks in Apstra but never assigning the required resource pools to the blueprint resource groups. Apstra blocks blueprint commits until all mandatory resource groups have pools assigned.

---

### Changes

#### `tests/examples/project.yaml`
Added two optional fields to the `apstra.juniper.net/vrf` annotation:

```json
{
  "vrfName": "vrf-demo",
  "vniPoolName": "eda-vni",
  "loopbackPoolName": "eda-ippool"
}




